### PR TITLE
Add optional MLP targeting to LoRA/LoKr and UI

### DIFF
--- a/acestep/training/configs.py
+++ b/acestep/training/configs.py
@@ -215,6 +215,11 @@ class TrainingConfig:
     seed: int = 42
     output_dir: str = "./lora_output"
 
+    # MLP targeting: "true" (default) or "false"
+    # When enabled, targets MLP modules (gate_proj, up_proj, down_proj) in addition to attention.
+    # Significantly increases parameters and quality, but uses more VRAM.
+    train_mlp: bool = False
+
     # Optimizer: "adamw" (default), "adamw8bit" (bitsandbytes), "adafactor", "prodigy"
     optimizer_type: str = "adamw"
 
@@ -375,6 +380,7 @@ class TrainingConfig:
             "snr_gamma": self.snr_gamma,
             "nan_detection_max": self.nan_detection_max,
             "audio_normalization": self.audio_normalization,
+            "train_mlp": self.train_mlp,
         }
 
 

--- a/acestep/training/lokr_utils.py
+++ b/acestep/training/lokr_utils.py
@@ -115,6 +115,15 @@ def inject_lokr_into_dit(
 
     # Build target module regex for LyCORIS
     target_modules = lokr_config.target_modules
+    
+    # Sync target_modules metadata if MLP training is requested
+    if train_mlp:
+        mlp_projs = ["gate_proj", "up_proj", "down_proj"]
+        for proj in mlp_projs:
+            if proj not in target_modules:
+                target_modules.append(proj)
+        logger.info(f"Expanded LoKr target_modules metadata to include MLP: {target_modules}")
+
     target_regex = _build_target_regex(target_modules, attention_type, train_mlp=train_mlp)
 
     logger.info(f"LoKr target pattern: {target_regex}")

--- a/acestep/training/lora_utils.py
+++ b/acestep/training/lora_utils.py
@@ -221,6 +221,7 @@ def inject_lora_into_dit(
     model,
     lora_config: LoRAConfig,
     attention_type: str = "both",
+    train_mlp: bool = False,
 ) -> Tuple[Any, Dict[str, Any]]:
     """Inject LoRA adapters into the DiT decoder of the model.
 
@@ -253,7 +254,32 @@ def inject_lora_into_dit(
         )
 
     # Resolve target modules based on attention type
-    resolved_targets = resolve_target_modules(model, lora_config, attention_type)
+    if train_mlp:
+        # Clone target modules to avoid mutating the original config
+        mlp_targets = ["gate_proj", "up_proj", "down_proj"]
+        original_targets = list(lora_config.target_modules)
+        for target in mlp_targets:
+            if target not in original_targets:
+                original_targets.append(target)
+        
+        # Temporarily override target_modules for resolution
+        from dataclasses import replace
+        modified_lora_config = replace(lora_config, target_modules=original_targets)
+        resolved_targets = resolve_target_modules(model, modified_lora_config, attention_type)
+        
+        # If filtering by attention, we MUST manually re-add the MLP modules
+        # because resolve_target_modules filters by "self_attn" or "cross_attn".
+        if attention_type != "both":
+            decoder = model.decoder if hasattr(model, 'decoder') else model
+            for name, module in decoder.named_modules():
+                if isinstance(module, nn.Linear):
+                    short_name = name.split(".")[-1]
+                    if short_name in mlp_targets and ".mlp." in name:
+                        if name not in resolved_targets:
+                            resolved_targets.append(name)
+            logger.info(f"MLP targeting enabled: added {len(mlp_targets)} projection types to {attention_type}-attention")
+    else:
+        resolved_targets = resolve_target_modules(model, lora_config, attention_type)
 
     # Get the decoder (DiT model)
     decoder = model.decoder

--- a/acestep/training/lora_utils.py
+++ b/acestep/training/lora_utils.py
@@ -255,17 +255,13 @@ def inject_lora_into_dit(
 
     # Resolve target modules based on attention type
     if train_mlp:
-        # Clone target modules to avoid mutating the original config
+        # Update target modules in the config to ensure they are persisted in metadata
         mlp_targets = ["gate_proj", "up_proj", "down_proj"]
-        original_targets = list(lora_config.target_modules)
         for target in mlp_targets:
-            if target not in original_targets:
-                original_targets.append(target)
+            if target not in lora_config.target_modules:
+                lora_config.target_modules.append(target)
         
-        # Temporarily override target_modules for resolution
-        from dataclasses import replace
-        modified_lora_config = replace(lora_config, target_modules=original_targets)
-        resolved_targets = resolve_target_modules(model, modified_lora_config, attention_type)
+        resolved_targets = resolve_target_modules(model, lora_config, attention_type)
         
         # If filtering by attention, we MUST manually re-add the MLP modules
         # because resolve_target_modules filters by "self_attn" or "cross_attn".

--- a/acestep/training/trainer.py
+++ b/acestep/training/trainer.py
@@ -360,6 +360,7 @@ class PreprocessedLoRAModule(nn.Module):
 
         # Inject adapter into the decoder
         attention_type = getattr(training_config, 'attention_type', 'both')
+        train_mlp = getattr(training_config, 'train_mlp', False)
 
         if adapter_type == "lokr":
             if not LOKR_IMPORTS_OK or not check_lycoris_available():
@@ -370,12 +371,12 @@ class PreprocessedLoRAModule(nn.Module):
             if lokr_config is None:
                 raise ValueError("lokr_config is required when adapter_type='lokr'")
             self.model, self.lycoris_net, self.lora_info = inject_lokr_into_dit(
-                model, lokr_config, attention_type=attention_type,
+                model, lokr_config, attention_type=attention_type, train_mlp=train_mlp
             )
-            logger.info(f"LoKr injected: {self.lora_info['trainable_params']:,} trainable params (attention: {attention_type})")
+            logger.info(f"LoKr injected: {self.lora_info['trainable_params']:,} trainable params (attention: {attention_type}, mlp: {train_mlp})")
         elif check_peft_available():
-            self.model, self.lora_info = inject_lora_into_dit(model, lora_config, attention_type=attention_type)
-            logger.info(f"LoRA injected: {self.lora_info['trainable_params']:,} trainable params (attention: {attention_type})")
+            self.model, self.lora_info = inject_lora_into_dit(model, lora_config, attention_type=attention_type, train_mlp=train_mlp)
+            logger.info(f"LoRA injected: {self.lora_info['trainable_params']:,} trainable params (attention: {attention_type}, mlp: {train_mlp})")
         else:
             self.model = model
             self.lora_info = {}

--- a/lora_training_ui.py
+++ b/lora_training_ui.py
@@ -1132,7 +1132,7 @@ def start_training(
     auto_save_best_after_val,
     max_latent_len, torch_compile_flag,
     model_type_val, guidance_scale_val, cfg_dropout_val, num_inference_steps_val,
-    optimizer_type_val, scheduler_type_val, attention_type_val,
+    optimizer_type_val, scheduler_type_val, attention_type_val, train_mlp_val,
     gradient_checkpointing_flag, encoder_offloading_flag,
     timestep_mu_val, timestep_sigma_val,
     resume_enabled, resume_dir, resume_checkpoint,
@@ -1243,6 +1243,7 @@ def start_training(
             optimizer_type=str(optimizer_type_val) if optimizer_type_val else "adamw",
             scheduler_type=str(scheduler_type_val) if scheduler_type_val else "cosine",
             attention_type=str(attention_type_val) if attention_type_val else "both",
+            train_mlp=bool(train_mlp_val),
             gradient_checkpointing=bool(gradient_checkpointing_flag),
             encoder_offloading=bool(encoder_offloading_flag),
             # Sample inference during training
@@ -2305,6 +2306,7 @@ def create_ui():
                             label="Attention Target",
                             info="Which attention layers to train: self, cross, or both",
                         )
+                        train_mlp = gr.Checkbox(label="Train MLP", value=False, info="Also train MLP projection layers (gate, up, down). Higher quality but more VRAM.")
 
                     with gr.Row(elem_classes="compact-row"):
                         model_type_radio = gr.Radio(
@@ -2740,7 +2742,7 @@ def create_ui():
                 early_stop_enabled, early_stop_patience_val, auto_save_best_after,
                 max_latent_length, torch_compile_enabled,
                 model_type_radio, guidance_scale, cfg_dropout_prob, num_inference_steps,
-                optimizer_type, scheduler_type, attention_type,
+                optimizer_type, scheduler_type, attention_type, train_mlp,
                 gradient_checkpointing_enabled, encoder_offloading_enabled,
                 timestep_mu, timestep_sigma,
                 resume_enabled, resume_dir, resume_checkpoint_dropdown,


### PR DESCRIPTION
This PR adds the ability to optionally target the Feed-Forward Network (MLP) layers of the DiT decoder during fine-tuning. Previously, only the attention layers were targeted.

**Changes:**
Core logic: Added a train_mlp flag to the training configuration.
LoRA/LoKr Utilities: Updated injection logic to target gate_proj, up_proj, and down_proj modules when train_mlp is enabled.
LoKr Support: Implemented regex-based targeting for LyCORIS (LoKr) to ensure MLP layers are correctly matched alongside attention layers.
UI Enhancement: Added a "Train MLP" checkbox to the Gradio interface for easy toggling.

**Why target MLPs?**
Higher Adaptation Quality: While attention layers govern how the model "attends" to different parts of the conditioning, the MLP layers act as the model's "knowledge store." Targeting them allows the LoRA/LoKr to capture more complex textures, timbres, and artisanal details of the training audio.
Flexibility: By making it an optional toggle, users can choose between "Attention-only" (standard VRAM usage) and "Attention + MLP" (higher quality, slightly higher VRAM).
Verification: Validated by inspecting the model structure and confirming the "Trainable Parameters" count increases correctly when the flag is toggled.